### PR TITLE
fix spelling

### DIFF
--- a/src/OTEL-djaglowski/OTEL.excalidraw
+++ b/src/OTEL-djaglowski/OTEL.excalidraw
@@ -931,14 +931,14 @@
       "updated": 1682412759187,
       "link": null,
       "locked": false,
-      "text": "Reciever",
+      "text": "Receiver",
       "fontSize": 38.39363376642491,
       "fontFamily": 1,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 34.00000000000001,
       "containerId": null,
-      "originalText": "Reciever",
+      "originalText": "Receiver",
       "lineHeight": 1.25
     },
     {


### PR DESCRIPTION
`Reciever` -> `Receiver`

The `assets/otel_collector_icons_djaglowski.png` file will also need to be regenerated, but I'm not sure how to do that.